### PR TITLE
:bug: Fixed TypeError when printing DatasetWithEntities

### DIFF
--- a/zshot/evaluation/dataset/dataset.py
+++ b/zshot/evaluation/dataset/dataset.py
@@ -30,4 +30,4 @@ class DatasetWithEntities(datasets.Dataset):
 
     def __repr__(self):
         return f"Dataset({{\n    features: {list(self.features.keys())},\n    num_rows: {self.num_rows}," \
-               f"\n    entities: {[ent['label'] for ent in self.entities if self.entities is not None]}\n}})"
+               f"\n    entities: {[ent.name for ent in self.entities if self.entities is not None]}\n}})"


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | #3  |

## Problem

`TypeError` raises when printing a DatasetWithEntities. See #3 

## Solution

Access the name of the entity instead of treating it like a `dict`

Closes #3 