### PR TITLE
Feat/zshot version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [egg_info]
 tag_svn_revision = true
+
+[metadata]
+version = attr: zshot.__version__

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,23 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
+from zshot import name, version, author, url, license_
+
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
-version = '0.0.2'
 
-setup(name='zshot',
+setup(name=name,
       version=version,
       description="Zero and Few shot named entity recognition",
       long_description_content_type='text/markdown',
       long_description=long_description,
       classifiers=[],
       keywords='NER Zero-Shot Few-Shot',
-      author='IBM Research',
+      author=author,
       author_email='',
-      url='https://ibm.github.io/zshot',
-      license='MIT',
+      url=url,
+      license=license_,
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,20 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-from zshot import name, version, author, url, license_
-
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 
-setup(name=name,
-      version=version,
+setup(name='zshot',
       description="Zero and Few shot named entity recognition",
       long_description_content_type='text/markdown',
       long_description=long_description,
       classifiers=[],
       keywords='NER Zero-Shot Few-Shot',
-      author=author,
+      author='IBM Research',
       author_email='',
-      url=url,
-      license=license_,
+      url='https://ibm.github.io/zshot',
+      license='MIT',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,

--- a/zshot/__init__.py
+++ b/zshot/__init__.py
@@ -1,8 +1,4 @@
 from zshot.zshot import MentionsExtractor, Linker, Zshot, PipelineConfig  # noqa: F401
 from zshot.utils.displacy import displacy  # noqa: F401
 
-name = 'zshot'
-version = '0.0.2'
-url = 'https://ibm.github.io/zshot'
-license_ = 'MIT'
-author = 'IBM Research'
+__version__ = '0.0.3'

--- a/zshot/__init__.py
+++ b/zshot/__init__.py
@@ -1,2 +1,8 @@
 from zshot.zshot import MentionsExtractor, Linker, Zshot, PipelineConfig  # noqa: F401
 from zshot.utils.displacy import displacy  # noqa: F401
+
+name = 'zshot'
+version = '0.0.2'
+url = 'https://ibm.github.io/zshot'
+license_ = 'MIT'
+author = 'IBM Research'

--- a/zshot/evaluation/evaluator.py
+++ b/zshot/evaluation/evaluator.py
@@ -34,7 +34,8 @@ class ZeroShotTokenClassificationEvaluator(TokenClassificationEvaluator):
             feature_extractor=None,  # noqa: F821
             device: int = None,
     ):
-        pipe = super(TokenClassificationEvaluator, self).prepare_pipeline(model_or_pipeline, tokenizer, feature_extractor, device)
+        pipe = super(TokenClassificationEvaluator, self).prepare_pipeline(model_or_pipeline, tokenizer,
+                                                                          feature_extractor, device)
         return pipe
 
 

--- a/zshot/evaluation/zshot_evaluate.py
+++ b/zshot/evaluation/zshot_evaluate.py
@@ -5,13 +5,12 @@ from evaluate import EvaluationModule
 from prettytable import PrettyTable
 
 from zshot.evaluation import load_medmentions, load_ontonotes
-from zshot.evaluation.dataset.dataset import DatasetWithEntities
 from zshot.evaluation.evaluator import ZeroShotTokenClassificationEvaluator, MentionsExtractorEvaluator
 from zshot.evaluation.pipeline import LinkerPipeline, MentionsExtractorPipeline
 
 
 def evaluate(nlp: spacy.language.Language,
-             datasets: Union[DatasetWithEntities, List[DatasetWithEntities]],
+             datasets: Union[str, List[str]],
              splits: Optional[Union[str, List[str]]] = None,
              metric: Optional[Union[str, EvaluationModule]] = None,
              batch_size: Optional[int] = 16) -> str:
@@ -30,6 +29,9 @@ def evaluate(nlp: spacy.language.Language,
 
     if type(splits) == str:
         splits = [splits]
+
+    if type(datasets) == str:
+        datasets = [datasets]
 
     result = {}
     field_names = ["Metric"]

--- a/zshot/tests/evaluation/test_evaluation.py
+++ b/zshot/tests/evaluation/test_evaluation.py
@@ -113,7 +113,7 @@ class TestZeroShotTokenClassificationEvaluation:
         dataset = get_dataset(gt, sentences)
 
         custom_evaluator = ZeroShotTokenClassificationEvaluator("token-classification")
-        metrics = custom_evaluator.compute(get_linker_pipe([('New York', 'FAC', 1)]), dataset, "seqeval")
+        metrics = custom_evaluator.compute(get_linker_pipe([('New York', 'FAC', 1)]), dataset, metric="seqeval")
 
         assert float(metrics["overall_precision"]) == 1.0
         assert float(metrics["overall_precision"]) == 1.0
@@ -128,7 +128,7 @@ class TestZeroShotTokenClassificationEvaluation:
 
         custom_evaluator = ZeroShotTokenClassificationEvaluator("token-classification")
         metrics = custom_evaluator.compute(get_linker_pipe([('New York', 'FAC', 1), ('York', 'LOC', 0.7)]), dataset,
-                                           "seqeval")
+                                           metric="seqeval")
 
         assert float(metrics["overall_precision"]) == 1.0
         assert float(metrics["overall_precision"]) == 1.0
@@ -144,7 +144,7 @@ class TestZeroShotTokenClassificationEvaluation:
         custom_evaluator = ZeroShotTokenClassificationEvaluator("token-classification",
                                                                 alignment_mode=AlignmentMode.expand)
         pipe = get_linker_pipe([('New Yo', 'FAC', 1)])
-        metrics = custom_evaluator.compute(pipe, dataset, "seqeval")
+        metrics = custom_evaluator.compute(pipe, dataset, metric="seqeval")
 
         assert float(metrics["overall_precision"]) == 1.0
         assert float(metrics["overall_precision"]) == 1.0
@@ -160,7 +160,7 @@ class TestZeroShotTokenClassificationEvaluation:
         custom_evaluator = ZeroShotTokenClassificationEvaluator("token-classification",
                                                                 alignment_mode=AlignmentMode.contract)
         pipe = get_linker_pipe([('New York i', 'FAC', 1)])
-        metrics = custom_evaluator.compute(pipe, dataset, "seqeval")
+        metrics = custom_evaluator.compute(pipe, dataset, metric="seqeval")
 
         assert float(metrics["overall_precision"]) == 1.0
         assert float(metrics["overall_precision"]) == 1.0
@@ -176,7 +176,7 @@ class TestZeroShotTokenClassificationEvaluation:
         custom_evaluator = ZeroShotTokenClassificationEvaluator("token-classification",
                                                                 alignment_mode=AlignmentMode.contract)
         pipe = get_linker_pipe([('New York i', 'FAC', 1), ('w York', 'LOC', 0.7)])
-        metrics = custom_evaluator.compute(pipe, dataset, "seqeval")
+        metrics = custom_evaluator.compute(pipe, dataset, metric="seqeval")
 
         assert float(metrics["overall_precision"]) == 1.0
         assert float(metrics["overall_precision"]) == 1.0
@@ -207,7 +207,8 @@ class TestMentionsExtractorEvaluator:
         dataset = get_dataset(gt, sentences)
 
         custom_evaluator = MentionsExtractorEvaluator("token-classification")
-        metrics = custom_evaluator.compute(get_mentions_extractor_pipe([('New York', 'FAC', 1)]), dataset, "seqeval")
+        metrics = custom_evaluator.compute(get_mentions_extractor_pipe([('New York', 'FAC', 1)]), dataset,
+                                           metric="seqeval")
 
         assert float(metrics["overall_precision"]) == 1.0
         assert float(metrics["overall_precision"]) == 1.0
@@ -222,7 +223,7 @@ class TestMentionsExtractorEvaluator:
 
         custom_evaluator = MentionsExtractorEvaluator("token-classification")
         metrics = custom_evaluator.compute(get_mentions_extractor_pipe([('New York', 'FAC', 1), ('York', 'LOC', 0.7)]),
-                                           dataset, "seqeval")
+                                           dataset, metric="seqeval")
 
         assert float(metrics["overall_precision"]) == 1.0
         assert float(metrics["overall_precision"]) == 1.0
@@ -238,7 +239,7 @@ class TestMentionsExtractorEvaluator:
         custom_evaluator = MentionsExtractorEvaluator("token-classification",
                                                       alignment_mode=AlignmentMode.expand)
         pipe = get_mentions_extractor_pipe([('New Yo', 'FAC', 1)])
-        metrics = custom_evaluator.compute(pipe, dataset, "seqeval")
+        metrics = custom_evaluator.compute(pipe, dataset, metric="seqeval")
 
         assert float(metrics["overall_precision"]) == 1.0
         assert float(metrics["overall_precision"]) == 1.0


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Hold | Refactor | No |  |

## Problem

- Refactor `__init__.py` and `setup.py`.

The version is in the `setup.py` file. This doesn't allow doing things like:
```python
import zshot

print(zshot.__version__)
```

- The evaluation tests are failing with latest version of `evaluate`.

In latest version 0.3 of `evaluate` they don't receive a metric as a positional argument, it must be a keyword argument.

## Solution

- Refactor `__init__.py` and `setup.py`.

Moving the version to `setup.cfg` in the `[metadata]` field, as proposed in the [official guide](https://packaging.python.org/en/latest/guides/single-sourcing-package-version/).

- The evaluation tests are failing with latest version of `evaluate`.

Add the metric as a keyword argument to the function call in the tests.

## Other changes (e.g. bug fixes, small refactors)

- Fixed typo and formatting in `zshot/evaluation/evaluator.py` and `zshot/evaluation/zshot_evaluate.py`