### PR TITLE
:bug: Fixed bug in pipeline config with mentions and entities

### DIFF
--- a/zshot/pipeline_config.py
+++ b/zshot/pipeline_config.py
@@ -1,3 +1,4 @@
+import random
 from typing import Optional, Union, List
 
 import spacy
@@ -41,7 +42,8 @@ class PipelineConfig(dict):
     @staticmethod
     def param(param) -> str:
         if isinstance(param, list):
-            instance_hash = hash(hash(param[0]) + hash(param[-1]))
+            params_to_hash = random.sample(param, k=min(len(param), 10))
+            instance_hash = hash(sum([hash(param_to_hash) for param_to_hash in params_to_hash]))
         else:
             instance_hash = hash(param)
 

--- a/zshot/zshot.py
+++ b/zshot/zshot.py
@@ -51,10 +51,14 @@ class Zshot:
             self.mentions = spacy_registry.get(registry_name='misc', func_name=self.mentions)()
         if isinstance(self.mentions, list) and len(self.mentions) > 0 and isinstance(self.mentions[0], dict):
             self.mentions = list(map(lambda e: Entity(**e), self.mentions))
+        if isinstance(self.mentions, list) and len(self.mentions) > 0 and isinstance(self.mentions[0], str):
+            self.mentions = list(map(lambda e: Entity(name=e, description=""), self.mentions))
         if isinstance(self.entities, str):
             self.entities = spacy_registry.get(registry_name='misc', func_name=self.entities)()
         if isinstance(self.entities, list) and len(self.entities) > 0 and isinstance(self.entities[0], dict):
             self.entities = list(map(lambda e: Entity(**e), self.entities))
+        if isinstance(self.entities, list) and len(self.entities) > 0 and isinstance(self.entities[0], str):
+            self.entities = list(map(lambda e: Entity(name=e, description=""), self.entities))
 
         # Load Mention Extractor from registered function ID if provided
         if isinstance(self.mentions_extractor, str):


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | Yes | [Link](https://github.com/IBM/zshot/issues/25) |

## Problem

_What problem are you trying to solve?_

When using both `mentions` and `entities` in `PipelineConfig`, if they have the same first and last element the hash will be the same, thus the `mentions` will be overridden with the `entities`.

## Solution

_How did you solve the problem?_

In `PipelineConfig`, now the hashing is done by taking 10 random items from the list of entities/mentions, or all of them if there are less than 10.

## Other changes (e.g. bug fixes, small refactors)
Added conversion to Entity when a list of strings is passed.