### PR TITLE
:bug: Fix bug in displacy serve method

### DIFF
--- a/zshot/utils/displacy/displacy.py
+++ b/zshot/utils/displacy/displacy.py
@@ -72,5 +72,8 @@ class displacy:
                     return display(HTML('<span class="tex2jax_ignore">{}</span>'.format(html)))
             return html
 
+        if method == "render":
+            kwargs.update({"jupyter": jupyter})
+
         disp = getattr(s_displacy, method)
-        return disp(docs, style=style, options=options, jupyter=jupyter, **kwargs)
+        return disp(docs, style=style, options=options, **kwargs)


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | [#45](https://github.com/IBM/zshot/issues/45) |

## Problem

Issue #45 
```
 TypeError: serve() got an unexpected keyword argument 'jupyter'
```

## Solution

Add `jupyter` option to `kwargs` in case it's `render` method. 


Closes #45 