### PR TITLE
Fix RuntimeError in ZSBert

### DIFF
--- a/zshot/relation_extractor/zsrc/zero_shot_rel_class.py
+++ b/zshot/relation_extractor/zsrc/zero_shot_rel_class.py
@@ -17,7 +17,7 @@ def load_model(device: Optional[Union[str, torch.device]] = None):
     if not os.path.isfile(MODEL_PATH):
         download_file(MODEL_REMOTE_URL, MODELS_CACHE_PATH)
 
-    model.load_state_dict(torch.load(MODEL_PATH))
+    model.load_state_dict(torch.load(MODEL_PATH), strict=False)
     model.to(device)
     model.eval()
     return model


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | #59 |

## Problem

With `transformers>=4.31.0` ZSBert raised a `RuntimeError` while loading the state dict


## Solution

Add `strict=False` to `load_state_dict`