### PR TITLE
:bug: Fixed bug in Regen constrained generation

### DIFF
--- a/zshot/linker/linker_regen/linker_regen.py
+++ b/zshot/linker/linker_regen/linker_regen.py
@@ -64,7 +64,11 @@ class LinkerRegen(Linker):
 
     def restrict_decode_vocab(self, _, prefix_beam):
         """ Restrict the possibilities of the Beam search to force the text generation """
-        return self.trie.postfix(prefix_beam.tolist())
+        tokens = self.trie.postfix(prefix_beam.tolist())
+        if not tokens:
+            return [self.tokenizer.eos_token_id]
+
+        return tokens
 
     def predict(self, docs: Iterator[Doc], batch_size: Optional[Union[int, None]] = None) -> List[List[Span]]:
         """


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | #73 |

## Problem

`ValueError: prefix_allowed_tokens_fn` with new version of `transformers`


## Solution

When finished generation return `EOS` token instead of empty list.

Closes #73 