### PR TITLE
Fix predictions_to_span_annotations function to properly handle entit…

### DIFF
--- a/zshot/utils/models/smxm/utils.py
+++ b/zshot/utils/models/smxm/utils.py
@@ -41,24 +41,26 @@ def predictions_to_span_annotations(
         max_sentence_tokens: int,
 ) -> List[List[Span]]:
     span_annotations = []
-
-    for i, sentence_full in enumerate(sentences):  # Keep the original full sentence
-
+    for i, sentence_full in enumerate(sentences):
         sentence = sentence_full.split(" ")
         sentence_span_annotations = []
+        
         tokenization = tokenizer.encode_plus(
             sentence,
             return_token_type_ids=False,
             return_attention_mask=False,
             return_offsets_mapping=True,
-            is_split_into_words=True
+            is_split_into_words=True 
         )
-
-        num_tokens_full_sentence = len(tokenization["input_ids"]) - 2
+        
+        num_tokens_full_sentence = len(tokenization["input_ids"]) - 2  # Exclude [CLS] and [SEP]
         token_overflow = num_tokens_full_sentence - max_sentence_tokens
         truncation_offset = token_overflow * (token_overflow > 0)
-
+        
+        # Get mapping from tokens to words
         mapping_input_id_to_word = tokenization.encodings[0].word_ids
+        
+        # Create offset mappings for the words in the original sentence
         words_offset_mappings = {}
         word_index_offset = 0
         for word_index, word in enumerate(sentence):
@@ -66,32 +68,65 @@ def predictions_to_span_annotations(
             end_offset = start_offset + len(word)
             words_offset_mappings[word_index] = (start_offset, end_offset)
             word_index_offset = end_offset + 1
-
+        
+        # Track entity spans using B-I-O logic similar to the original function
+        current_entity = None
+        current_start = None
+        current_score = 0.0
+        
         for j, input_id in enumerate(mapping_input_id_to_word[truncation_offset:-1]):
-            if input_id is not None and input_id < len(sentence):
-                pred = predictions[i][j]
-                if (
-                        entities[pred] != "NEG"
-                ) and (
-                        (j == 0) or (input_id != mapping_input_id_to_word[j - 1])
-                ) and (
-                        (words_offset_mappings[input_id][1] - words_offset_mappings[input_id][0]) > 1
-                ):
-                    if (
-                            sentence_span_annotations and (sentence_span_annotations[-1].label == entities[pred])
-                    ) and (
-                            sentence_span_annotations[-1].end == words_offset_mappings[input_id][0] - 1
-                    ):
-                        sentence_span_annotations[-1].end = words_offset_mappings[input_id][1]
-                        sentence_span_annotations[-1].score = max(sentence_span_annotations[-1].score,
-                                                                  probabilities[i][j][pred])
-                    else:
+            if input_id is None:  # Skip special tokens
+                continue
+                
+            if input_id >= len(sentence):  # Handle potential out-of-bounds
+                continue
+                
+            pred = predictions[i][j]
+            entity_label = entities[pred]
+            
+            # Only process first subtoken of each word (like original function's removal of "#" tokens)
+            is_first_subtoken = (j == 0) or (input_id != mapping_input_id_to_word[j - 1])
+            
+            if is_first_subtoken:
+                if entity_label != "NEG":
+                    # Start new entity or continue current one
+                    if current_entity is None:
+                        # Start a new entity
+                        current_entity = entity_label
+                        current_start = words_offset_mappings[input_id][0]
+                        current_score = probabilities[i][j][pred]
+                    elif current_entity != entity_label:
+                        # Different entity - close the current one and start a new one
                         sentence_span_annotations.append(
-                            Span(words_offset_mappings[input_id][0], words_offset_mappings[input_id][1],
-                                 entities[pred], probabilities[i][j][pred])
+                            Span(current_start, words_offset_mappings[input_id - 1][1],
+                                 current_entity, current_score)
                         )
+                        current_entity = entity_label
+                        current_start = words_offset_mappings[input_id][0]
+                        current_score = probabilities[i][j][pred]
+                    else:
+                        # Same entity continues - update score if higher
+                        current_score = max(current_score, probabilities[i][j][pred])
+                else:
+                    # End any current entity
+                    if current_entity is not None:
+                        sentence_span_annotations.append(
+                            Span(current_start, words_offset_mappings[input_id - 1][1],
+                                 current_entity, current_score)
+                        )
+                        current_entity = None
+            
+        # Handle any final entity
+        if current_entity is not None and len(mapping_input_id_to_word) > 1:
+            last_valid_id = mapping_input_id_to_word[-2]  # Last non-special token
+            if last_valid_id is not None and last_valid_id < len(sentence):
+                sentence_span_annotations.append(
+                    Span(current_start, words_offset_mappings[last_valid_id][1],
+                         current_entity, current_score)
+                )
+                
         span_annotations.append(sentence_span_annotations)
-
+    
     return span_annotations
 
 


### PR DESCRIPTION
…y spans (#82)


| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | Yes | [Link](https://github.com/IBM/zshot/issues/82) |

## Problem
The `predictions_to_span_annotations` function produces lower evaluation scores compared to the original `evaluate_transformer` function when assessing the same model predictions. This inconsistency makes it difficult to reliably evaluate model performance.

## Solution
I modified the `predictions_to_span_annotations` function to better match the behavior of the original evaluation approach by:

1. Removing the unnecessary entity length restriction that was filtering out valid entities
2. Implementing proper IOB style logic for entity tracking
3. Fixing subtoken handling to match the original implementation's approach
4. Correcting entity boundary detection for more accurate span creation
5. Adding proper handling for final entities at the end of sentences

These changes ensure consistent evaluation metrics between both evaluation methods.

## Other changes (e.g. bug fixes, small refactors)
None