### PR TITLE
Fix alignment logic in align_spans function (#84)

### DIFF
--- a/zshot/utils/alignment_utils.py
+++ b/zshot/utils/alignment_utils.py
@@ -39,14 +39,22 @@ def align_spans(spans: List[Span], tokens: List[str], tokens_offsets: List[Tuple
         tokens_map = list(accumulate(map(lambda t: len(t) + len(join_by), tokens)))
         tokens_offsets = list(zip([0] + tokens_map, map(lambda x: x - len(join_by), tokens_map)))
     alignments = [[] for _ in range(len(tokens))]
+    
     for idt, (t_start, t_end) in enumerate(tokens_offsets):
         for ids, s in enumerate(spans):
-            if (t_start <= s.start < t_end or t_start < s.end <= t_end) and alignment_mode == AlignmentMode.expand:
-                alignments[idt].append(ids)
-            if t_start >= s.start and t_end <= s.end and alignment_mode == AlignmentMode.contract:
-                alignments[idt].append(ids)
-            if t_start > s.start and t_end < s.end:
-                alignments[idt].append(ids)
+            # Check if there's any overlap between token and span
+            if alignment_mode == AlignmentMode.expand:
+                # Token is at least partially covered by the span
+                # Either the token start or end is within the span, or the span is completely within the token
+                if (t_start <= s.start < t_end or  # span starts within token
+                    t_start < s.end <= t_end or    # span ends within token
+                    (s.start <= t_start and s.end >= t_end)):  # span completely covers token
+                    alignments[idt].append(ids)
+            elif alignment_mode == AlignmentMode.contract:
+                # Token is completely within the span
+                if t_start >= s.start and t_end <= s.end:
+                    alignments[idt].append(ids)
+                    
     if return_dict:
         return {
             'tokens_offsets': tokens_offsets,


### PR DESCRIPTION
> ⚠️ NOTE: This PR addresses a critical bug in the align_spans function that affects entity recognition accuracy and F1 scores.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | Yes | [Link](https://github.com/IBM/zshot/issues/84)|

## Problem

The `align_spans` function has an issue in its alignment logic that affects entity recognition accuracy. The current implementation has three checks for determining alignment, but they're not properly coordinated:

1. Two checks that depend on alignment_mode (expand or contract)
2. An unconditional third check that runs regardless of alignment mode

This third check causes incorrect alignments because it's checking for tokens completely contained inside spans unconditionally, which doesn't match the description of either alignment mode and leads to incorrect span assignments. This bug results in lower F1 scores for entity recognition tasks.

## Solution

I fixed the alignment logic to:

1. Handle all three overlap cases in `expand` mode:
   - When a span starts within a token
   - When a span ends within a token
   - When a span completely covers a token

2. Removed the unconditional third check (`t_start > s.start and t_end < s.end`) that was incorrectly aligning spans regardless of the alignment mode

3. Kept the `contract` mode behavior as intended, only including tokens that are completely within a span

4. Added clearer comments to improve code maintainability

## Other changes (e.g. bug fixes, small refactors)
- Improved code readability with better comments
- No new scripts or dependencies added